### PR TITLE
Fix Service fails to start when set self-start and multicast source

### DIFF
--- a/debian/udpxy.service
+++ b/debian/udpxy.service
@@ -5,6 +5,7 @@ After=network.target network-online.target
 
 [Service]
 Type=simple
+Restart=on-failure
 EnvironmentFile=/etc/default/udpxy
 ExecStart=/usr/bin/udpxy -T -p $UDPXY_PORT $UDPXY_OPTS
 

--- a/debian/udpxy.service
+++ b/debian/udpxy.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=udpxy: UDP multicast to TCP (HTTP) relay proxy
+Requires=network.target
 After=network.target
 
 [Service]

--- a/debian/udpxy.service
+++ b/debian/udpxy.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=udpxy: UDP multicast to TCP (HTTP) relay proxy
-Requires=network.target
-After=network.target
+Requires=network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=simple

--- a/debian/udpxy.service
+++ b/debian/udpxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=udpxy: UDP multicast to TCP (HTTP) relay proxy
-Requires=network.target network-online.target
+Requires=network-online.target
 After=network.target network-online.target
 
 [Service]


### PR DESCRIPTION
When I set this service self-start and set multicast source on the configuration, the service failed to start on Debian 10 boot.
According the syslog, systemd think that the service is not forced to rely on the network but that is not true, so systemd starts this service before the network initialization is complete.
Add ```Requires=network-online.target``` and ```Restart=on-failure``` to fix this bug.

According Syslog:
```
Oct 12 23:43:52 HOSTNAME systemd[1]: Started udpxy: UDP multicast to TCP (HTTP) relay proxy.
Oct 12 23:43:53 HOSTNAME udpxy[535]: Invalid multicast address: [ens34]
Oct 12 23:43:53 HOSTNAME systemd[1]: udpxy.service: Main process exited, code=exited, status=1/FAILURE
Oct 12 23:43:53 HOSTNAME systemd[1]: udpxy.service: Failed with result 'exit-code'.
```
